### PR TITLE
Improve compatibilty with rst2html5's literal blocks

### DIFF
--- a/docutils_basic.css
+++ b/docutils_basic.css
@@ -115,12 +115,12 @@ object[type="application/x-shockwave-flash"] {
 
 /* ========== Literal Blocks ========== */
 
-pre, tt.literal {
+pre, .literal {
     font-family: "Lucida Sans Typewriter", "Lucida Console", Monaco, "Bitstream Vera Sans Mono", monospace;
     font-size: 14px;
 }
 
-tt.literal {
+.literal {
     background-color: #ffa;
 }
 


### PR DESCRIPTION
The HTML5 writer in docutils doesn't add `tt` around literal blocks, because `tt` is deprecated in html5, so the following snippet:

```rst
``abc``
```

is translated to this:

```html
<body>
<div class="document">
<p><span class="docutils literal">abc</span></p>
</div>
</body>
```

This change ensures that literal text is properly highlighted when using rst2html5.